### PR TITLE
Core refactor

### DIFF
--- a/PCWidget/PCWidget.swift
+++ b/PCWidget/PCWidget.swift
@@ -9,7 +9,8 @@ import WidgetKit
 import SwiftUI
 import PastecardCore
 
-struct Provider: TimelineProvider {
+@MainActor
+struct Provider: @preconcurrency TimelineProvider {
     private let core = PastecardCore.shared
     
     func loadFromLocal() -> String {
@@ -86,7 +87,7 @@ extension View {
 
 struct PCWidget_Previews: PreviewProvider {
     static var previews: some View {
-        PCWidgetEntryView(entry: SimpleEntry(date: Date(), text: "Loading…"))
+        PCWidgetEntryView(entry: SimpleEntry(date: Date(), text: "Eggs, milk, bread"))
             .previewContext(WidgetPreviewContext(family: .systemMedium))
     }
 }

--- a/PCWidget/PCWidget.swift
+++ b/PCWidget/PCWidget.swift
@@ -7,41 +7,33 @@
 
 import WidgetKit
 import SwiftUI
+import PastecardCore
 
 struct Provider: TimelineProvider {
-    let defaults = UserDefaults(suiteName: "group.net.pastecard")!
-
+    private let core = PastecardCore.shared
+    
     func loadFromLocal() -> String {
-        let user = defaults.string(forKey: "ID")
-        var text = ""
-        
-        if user == nil {
-            text = "⚠️\n\nPlease sign in first."
-            return text
+        if !core.isSignedIn {
+            return "⚠️\n\nPlease sign in first."
         }
         
-        if let localText = defaults.string(forKey: "text") {
-            if !localText.isEmpty {
-                text = localText
-            }
-        }
-        return text
+        return core.loadLocal()
     }
     
     func placeholder(in context: Context) -> SimpleEntry {
         SimpleEntry(date: Date(), text: "Loading…")
     }
-
+    
     func getSnapshot(in context: Context, completion: @escaping (SimpleEntry) -> ()) {
         let entry = SimpleEntry(date: Date(), text: loadFromLocal())
         completion(entry)
     }
-
+    
     func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
         var entries: [SimpleEntry] = []
         let entry = SimpleEntry(date: Date(), text: loadFromLocal())
         entries.append(entry)
-
+        
         let timeline = Timeline(entries: entries, policy: .never)
         completion(timeline)
     }
@@ -54,25 +46,25 @@ struct SimpleEntry: TimelineEntry {
 
 struct PCWidgetEntryView : View {
     var entry: Provider.Entry
-
+    
     var body: some View {
-            VStack(spacing: 0) {
-                Rectangle()
-                    .fill(Color("AccentColor"))
-                    .frame(height:18)
-                    .widgetAccentable()
-                Text(entry.text)
-                    .padding(12)
-                    .font(.body)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            }
-            .widgetBackground(backgroundView: Color(UIColor.systemBackground))
+        VStack(spacing: 0) {
+            Rectangle()
+                .fill(Color("AccentColor"))
+                .frame(height:18)
+                .widgetAccentable()
+            Text(entry.text)
+                .padding(12)
+                .font(.body)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
+        .widgetBackground(backgroundView: Color(UIColor.systemBackground))
+    }
 }
 
 struct PCWidget: Widget {
     let kind: String = "PCWidget"
-
+    
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: Provider()) { entry in
             PCWidgetEntryView(entry: entry)
@@ -85,13 +77,10 @@ struct PCWidget: Widget {
 
 extension View {
     func widgetBackground(backgroundView: some View) -> some View {
-        if #available(iOSApplicationExtension 17.0, *) {
-            return containerBackground(for: .widget) {
-                backgroundView
-            }
-        } else {
-            return background(backgroundView)
+        return containerBackground(for: .widget) {
+            backgroundView
         }
+        
     }
 }
 

--- a/Pastecard.xcodeproj/project.pbxproj
+++ b/Pastecard.xcodeproj/project.pbxproj
@@ -412,7 +412,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = PCShareExt/PCShareExt.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PCShareExt/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = PCShareExt;
@@ -442,7 +442,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = PCShareExt/PCShareExt.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PCShareExt/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = PCShareExt;
@@ -475,7 +475,7 @@
 				CODE_SIGN_ENTITLEMENTS = PCWidget/PCWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PCWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = PCWidget;
@@ -509,7 +509,7 @@
 				CODE_SIGN_ENTITLEMENTS = PCWidget/PCWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PCWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = PCWidget;
@@ -664,7 +664,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = Pastecard/Pastecard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_ASSET_PATHS = "\"Pastecard/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -704,7 +704,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = Pastecard/Pastecard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_ASSET_PATHS = "\"Pastecard/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Pastecard.xcodeproj/project.pbxproj
+++ b/Pastecard.xcodeproj/project.pbxproj
@@ -13,10 +13,11 @@
 		7A152D07296DC84C00EF049D /* SafariViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A152D06296DC84C00EF049D /* SafariViewController.swift */; };
 		7A417C66296B14C6002E8B4D /* SwipeMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A417C65296B14C6002E8B4D /* SwipeMenu.swift */; };
 		7A417C68296B1CC4002E8B4D /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A417C67296B1CC4002E8B4D /* SignInView.swift */; };
+		7A46838A2E14445D00514B82 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4683892E14445600514B82 /* NetworkMonitor.swift */; };
+		7A46838C2E14549100514B82 /* Shortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A46838B2E14549100514B82 /* Shortcuts.swift */; };
 		7A536FE5299D1266002A8E85 /* SignUpSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A536FE4299D1266002A8E85 /* SignUpSheet.swift */; };
 		7A5A5FEE2B6371A800BD1150 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7A5A5FED2B6371A800BD1150 /* Colors.xcassets */; };
 		7A7BC8D42A3D0B8200BAB585 /* AppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A27FED92A37F0050063CF02 /* AppIntents.swift */; };
-		7A7BC8D52A3D0B8200BAB585 /* Shortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A142E582A38D10C00090E98 /* Shortcuts.swift */; };
 		7AD1E1A929EF2FC7003262F3 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD1E1A829EF2FC7003262F3 /* ShareViewController.swift */; };
 		7AD1E1B029EF2FC7003262F3 /* PCShareExt.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 7AD1E1A629EF2FC6003262F3 /* PCShareExt.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		7AD1E1BC29EF3EFD003262F3 /* SwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD1E1BB29EF3EFD003262F3 /* SwiftUIView.swift */; };
@@ -76,11 +77,12 @@
 
 /* Begin PBXFileReference section */
 		7A0401202BB1B1C10042FB3A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		7A142E582A38D10C00090E98 /* Shortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shortcuts.swift; sourceTree = "<group>"; };
 		7A152D06296DC84C00EF049D /* SafariViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariViewController.swift; sourceTree = "<group>"; };
 		7A27FED92A37F0050063CF02 /* AppIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntents.swift; sourceTree = "<group>"; };
 		7A417C65296B14C6002E8B4D /* SwipeMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeMenu.swift; sourceTree = "<group>"; };
 		7A417C67296B1CC4002E8B4D /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
+		7A4683892E14445600514B82 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
+		7A46838B2E14549100514B82 /* Shortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shortcuts.swift; sourceTree = "<group>"; };
 		7A536FE4299D1266002A8E85 /* SignUpSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpSheet.swift; sourceTree = "<group>"; };
 		7A5A5FED2B6371A800BD1150 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		7AD1E1A629EF2FC6003262F3 /* PCShareExt.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = PCShareExt.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -195,13 +197,14 @@
 				7AFC09BF290AC47C009CAC71 /* PastecardApp.swift */,
 				7AE7F75B2A0164EF007194F5 /* AppDelegate.swift */,
 				7ADD85832999451F00A7292C /* Pastecard.swift */,
+				7A4683892E14445600514B82 /* NetworkMonitor.swift */,
 				7AFC09C1290AC47C009CAC71 /* CardView.swift */,
 				7A417C65296B14C6002E8B4D /* SwipeMenu.swift */,
 				7A417C67296B1CC4002E8B4D /* SignInView.swift */,
 				7A536FE4299D1266002A8E85 /* SignUpSheet.swift */,
 				7A152D06296DC84C00EF049D /* SafariViewController.swift */,
+				7A46838B2E14549100514B82 /* Shortcuts.swift */,
 				7A27FED92A37F0050063CF02 /* AppIntents.swift */,
-				7A142E582A38D10C00090E98 /* Shortcuts.swift */,
 				7AFC09C3290AC47D009CAC71 /* Assets.xcassets */,
 				7AFC09C5290AC47D009CAC71 /* Preview Content */,
 			);
@@ -282,7 +285,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1430;
-				LastUpgradeCheck = 1600;
+				LastUpgradeCheck = 1640;
 				TargetAttributes = {
 					7AD1E1A529EF2FC6003262F3 = {
 						CreatedOnToolsVersion = 14.3;
@@ -369,7 +372,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7A46838A2E14445D00514B82 /* NetworkMonitor.swift in Sources */,
 				7AE7F75C2A0164EF007194F5 /* AppDelegate.swift in Sources */,
+				7A46838C2E14549100514B82 /* Shortcuts.swift in Sources */,
 				7AFC09C2290AC47C009CAC71 /* CardView.swift in Sources */,
 				7AFC09C0290AC47C009CAC71 /* PastecardApp.swift in Sources */,
 				7A536FE5299D1266002A8E85 /* SignUpSheet.swift in Sources */,
@@ -378,7 +383,6 @@
 				7A7BC8D42A3D0B8200BAB585 /* AppIntents.swift in Sources */,
 				7A417C68296B1CC4002E8B4D /* SignInView.swift in Sources */,
 				7A417C66296B14C6002E8B4D /* SwipeMenu.swift in Sources */,
-				7A7BC8D52A3D0B8200BAB585 /* Shortcuts.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -404,7 +408,6 @@
 				CODE_SIGN_ENTITLEMENTS = PCShareExt/PCShareExt.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 13;
-				DEVELOPMENT_TEAM = 4JC57Z4N28;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PCShareExt/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = PCShareExt;
@@ -435,7 +438,6 @@
 				CODE_SIGN_ENTITLEMENTS = PCShareExt/PCShareExt.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 13;
-				DEVELOPMENT_TEAM = 4JC57Z4N28;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PCShareExt/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = PCShareExt;
@@ -469,7 +471,6 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 13;
-				DEVELOPMENT_TEAM = 4JC57Z4N28;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PCWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = PCWidget;
@@ -504,7 +505,6 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 13;
-				DEVELOPMENT_TEAM = 4JC57Z4N28;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PCWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = PCWidget;
@@ -565,6 +565,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 4JC57Z4N28;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -582,7 +583,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -627,6 +628,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 4JC57Z4N28;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -638,7 +640,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -659,7 +661,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_ASSET_PATHS = "\"Pastecard/Preview Content\"";
-				DEVELOPMENT_TEAM = 4JC57Z4N28;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Pastecard/Info.plist;
@@ -699,7 +700,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_ASSET_PATHS = "\"Pastecard/Preview Content\"";
-				DEVELOPMENT_TEAM = 4JC57Z4N28;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Pastecard/Info.plist;

--- a/Pastecard.xcodeproj/project.pbxproj
+++ b/Pastecard.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -18,6 +18,9 @@
 		7A536FE5299D1266002A8E85 /* SignUpSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A536FE4299D1266002A8E85 /* SignUpSheet.swift */; };
 		7A5A5FEE2B6371A800BD1150 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7A5A5FED2B6371A800BD1150 /* Colors.xcassets */; };
 		7A7BC8D42A3D0B8200BAB585 /* AppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A27FED92A37F0050063CF02 /* AppIntents.swift */; };
+		7AA9B5F22E156C440002B7B3 /* PastecardCore in Frameworks */ = {isa = PBXBuildFile; productRef = 7AA9B5F12E156C440002B7B3 /* PastecardCore */; };
+		7AA9B5F42E156C4D0002B7B3 /* PastecardCore in Frameworks */ = {isa = PBXBuildFile; productRef = 7AA9B5F32E156C4D0002B7B3 /* PastecardCore */; };
+		7AA9B5F62E156C520002B7B3 /* PastecardCore in Frameworks */ = {isa = PBXBuildFile; productRef = 7AA9B5F52E156C520002B7B3 /* PastecardCore */; };
 		7AD1E1A929EF2FC7003262F3 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD1E1A829EF2FC7003262F3 /* ShareViewController.swift */; };
 		7AD1E1B029EF2FC7003262F3 /* PCShareExt.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 7AD1E1A629EF2FC6003262F3 /* PCShareExt.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		7AD1E1BC29EF3EFD003262F3 /* SwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD1E1BB29EF3EFD003262F3 /* SwiftUIView.swift */; };
@@ -94,8 +97,6 @@
 		7AE7F75B2A0164EF007194F5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AEC325D29E9ED08000B30EA /* Pastecard.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Pastecard.entitlements; sourceTree = "<group>"; };
 		7AEC326229E9F136000B30EA /* PCWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = PCWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		7AEC326429E9F136000B30EA /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
-		7AEC326629E9F136000B30EA /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		7AEC326929E9F136000B30EA /* PCWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCWidgetBundle.swift; sourceTree = "<group>"; };
 		7AEC326B29E9F136000B30EA /* PCWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCWidget.swift; sourceTree = "<group>"; };
 		7AEC326D29E9F137000B30EA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -114,6 +115,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7AA9B5F62E156C520002B7B3 /* PastecardCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -121,6 +123,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7AA9B5F42E156C4D0002B7B3 /* PastecardCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -128,6 +131,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7AA9B5F22E156C440002B7B3 /* PastecardCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -149,8 +153,6 @@
 		7AEC326329E9F136000B30EA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				7AEC326429E9F136000B30EA /* WidgetKit.framework */,
-				7AEC326629E9F136000B30EA /* SwiftUI.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -307,6 +309,9 @@
 				Base,
 			);
 			mainGroup = 7AFC09B3290AC47C009CAC71;
+			packageReferences = (
+				7AA9B5EE2E156B760002B7B3 /* XCLocalSwiftPackageReference "PastecardCore" */,
+			);
 			productRefGroup = 7AFC09BD290AC47C009CAC71 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -407,18 +412,18 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = PCShareExt/PCShareExt.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PCShareExt/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = PCShareExt;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = net.pastecard.Pastecard.PCShareExt;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -437,18 +442,18 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = PCShareExt/PCShareExt.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PCShareExt/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = PCShareExt;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = net.pastecard.Pastecard.PCShareExt;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -470,18 +475,18 @@
 				CODE_SIGN_ENTITLEMENTS = PCWidget/PCWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PCWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = PCWidget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = net.pastecard.Pastecard.PCWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -504,18 +509,18 @@
 				CODE_SIGN_ENTITLEMENTS = PCWidget/PCWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PCWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = PCWidget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = net.pastecard.Pastecard.PCWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -659,7 +664,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = Pastecard/Pastecard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_ASSET_PATHS = "\"Pastecard/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -672,11 +677,12 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = net.pastecard.Pastecard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -698,7 +704,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = Pastecard/Pastecard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_ASSET_PATHS = "\"Pastecard/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -711,11 +717,12 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = net.pastecard.Pastecard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -768,6 +775,31 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		7AA9B5EE2E156B760002B7B3 /* XCLocalSwiftPackageReference "PastecardCore" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = PastecardCore;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		7AA9B5F12E156C440002B7B3 /* PastecardCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7AA9B5EE2E156B760002B7B3 /* XCLocalSwiftPackageReference "PastecardCore" */;
+			productName = PastecardCore;
+		};
+		7AA9B5F32E156C4D0002B7B3 /* PastecardCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7AA9B5EE2E156B760002B7B3 /* XCLocalSwiftPackageReference "PastecardCore" */;
+			productName = PastecardCore;
+		};
+		7AA9B5F52E156C520002B7B3 /* PastecardCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7AA9B5EE2E156B760002B7B3 /* XCLocalSwiftPackageReference "PastecardCore" */;
+			productName = PastecardCore;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 7AFC09B4290AC47C009CAC71 /* Project object */;
 }

--- a/Pastecard.xcodeproj/xcshareddata/xcschemes/PCShareExt.xcscheme
+++ b/Pastecard.xcodeproj/xcshareddata/xcschemes/PCShareExt.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "1640"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/Pastecard.xcodeproj/xcshareddata/xcschemes/PCWidget.xcscheme
+++ b/Pastecard.xcodeproj/xcshareddata/xcschemes/PCWidget.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "1640"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/Pastecard.xcodeproj/xcshareddata/xcschemes/Pastecard.xcscheme
+++ b/Pastecard.xcodeproj/xcshareddata/xcschemes/Pastecard.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "1640"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Pastecard/AppIntents.swift
+++ b/Pastecard/AppIntents.swift
@@ -17,11 +17,11 @@ struct GetText: AppIntent {
     private let core = PastecardCore.shared
     
     private func loadText() async throws -> String {
-        if await !core.isSignedIn {
+        if !core.isSignedIn {
             return "Please sign in first."
         }
         
-        let localText = await core.loadLocal()
+        let localText = core.loadLocal()
         if !localText.isEmpty {
             return localText
         } else {
@@ -52,7 +52,7 @@ struct AppendText: AppIntent {
     private let core = PastecardCore.shared
     
     private func append(_ newText: String) async throws -> String {
-        if await !core.isSignedIn {
+        if !core.isSignedIn {
             return "Please sign in first."
         }
         

--- a/Pastecard/AppIntents.swift
+++ b/Pastecard/AppIntents.swift
@@ -17,11 +17,11 @@ struct GetText: AppIntent {
     private let core = PastecardCore.shared
     
     private func loadText() async throws -> String {
-        if !core.isSignedIn {
+        if await !core.isSignedIn {
             return "Please sign in first."
         }
         
-        let localText = core.loadLocal()
+        let localText = await core.loadLocal()
         if !localText.isEmpty {
             return localText
         } else {
@@ -52,7 +52,7 @@ struct AppendText: AppIntent {
     private let core = PastecardCore.shared
     
     private func append(_ newText: String) async throws -> String {
-        if !core.isSignedIn {
+        if await !core.isSignedIn {
             return "Please sign in first."
         }
         

--- a/Pastecard/AppIntents.swift
+++ b/Pastecard/AppIntents.swift
@@ -6,34 +6,28 @@
 //
 
 import AppIntents
+import PastecardCore
 
 struct GetText: AppIntent {
     static var title: LocalizedStringResource = "Pastecard text"
-    static var description = IntentDescription("Returns the text on your Pastecard.")
+    static var description =
+    IntentDescription("Returns the text on your Pastecard.")
     static var openAppWhenRun = false
     
+    private let core = PastecardCore.shared
+    
     private func loadText() async throws -> String {
-        let defaults = UserDefaults(suiteName: "group.net.pastecard")!
-        let user = defaults.string(forKey: "ID")
-        var returnText = ""
-        
-        if user == nil {
+        if !core.isSignedIn {
             return "Please sign in first."
         }
-        else if let localText = defaults.string(forKey: "text") {
-            if !localText.isEmpty {
-                returnText = localText
-            } else {
-                let randomInt = String(Int.random(in: 1...1000))
-                let url = URL(string: "https://pastecard.net/api/db/" + user! + ".txt?" + randomInt)!
-                let (data, response) = try await URLSession.shared.data(from: url)
-                let remoteText = String(decoding: data, as: UTF8.self)
-                guard (response as? HTTPURLResponse)?.statusCode == 200 else { throw NetworkError.loadError }
-                if !remoteText.isEmpty { returnText = remoteText }
-            }
-        }
         
-        return returnText
+        let localText = core.loadLocal()
+        if !localText.isEmpty {
+            return localText
+        } else {
+            // If local is empty, try to load from remote
+            return try await core.loadRemote()
+        }
     }
     
     func perform() async throws -> some ReturnsValue<String> & ProvidesDialog {
@@ -53,30 +47,17 @@ struct AppendText: AppIntent {
     var text: String?
     static var parameterSummary: some ParameterSummary {
         Summary("Add \(\.$text) to your Pastecard")
-      }
+    }
+    
+    private let core = PastecardCore.shared
     
     private func append(_ newText: String) async throws -> String {
-        let user = UserDefaults(suiteName: "group.net.pastecard")!.string(forKey: "ID")
-        let sendText = newText.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? ""
-        
-        if user == nil {
+        if !core.isSignedIn {
             return "Please sign in first."
         }
-        else {
-            let postData = ("user=" + user! + "&text=" + sendText)
-            let url = URL(string: "https://pastecard.net/api/ios-append.php")!
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            request.httpBody = postData.data(using: String.Encoding.utf8)
-            request.timeoutInterval = 5.0
-            
-            let (_, response) = try await URLSession.shared.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-                throw NetworkError.appendError
-            }
-            
-            return "Saved!"
-        }
+        
+        try await core.append(newText)
+        return "Saved!"
     }
     
     func perform() async throws -> some ProvidesDialog {

--- a/Pastecard/AppIntents.swift
+++ b/Pastecard/AppIntents.swift
@@ -9,8 +9,7 @@ import AppIntents
 
 struct GetText: AppIntent {
     static var title: LocalizedStringResource = "Pastecard text"
-    static var description =
-    IntentDescription("Returns the text on your Pastecard.")
+    static var description = IntentDescription("Returns the text on your Pastecard.")
     static var openAppWhenRun = false
     
     private func loadText() async throws -> String {

--- a/Pastecard/CardView.swift
+++ b/Pastecard/CardView.swift
@@ -23,6 +23,7 @@ struct CardView: View {
     @FocusState private var isFocused: Bool
     @State private var showEmptyState = false
     @State private var animateTip = false
+    @State private var lastRefreshed = Date()
     
     // Debounced loading to prevent excessive refreshes
     @State private var loadTask: Task<Void, Never>?
@@ -148,7 +149,7 @@ struct CardView: View {
     }
     
     private func loadTextIfOld() async {
-        if Date().timeIntervalSince(card.lastRefreshTime) > 30 { // 30 seconds
+        if Date().timeIntervalSince(lastRefreshed) > 30 { // 30 seconds
             Task {
                 do {
                     try await card.refresh()
@@ -158,6 +159,7 @@ struct CardView: View {
                 }
             }
         }
+        lastRefreshed = Date()
         updateEmptyState()
     }
     
@@ -222,7 +224,9 @@ struct CardView: View {
     private func handleScenePhaseChange(_ newPhase: ScenePhase) {
         switch newPhase {
         case .active:
+            // Handle Swap Icon call
             performActionIfCalled()
+           
             // Debounced refresh when coming back to foreground
             loadTask?.cancel()
             loadTask = Task {

--- a/Pastecard/CardView.swift
+++ b/Pastecard/CardView.swift
@@ -12,16 +12,31 @@ struct CardView: View {
     @EnvironmentObject var card: Pastecard
     @EnvironmentObject var actionService: ActionService
     @Environment(\.scenePhase) var scenePhase
+    @StateObject private var networkMonitor = NetworkMonitor()
     
-    @State private var text = "Loading…"
-    @State private var locked = true
-    @State private var savedText = ""
-    @State private var cancelText = ""
+    @State private var editingText = ""
+    @State private var isEditing = false
     @State private var showMenu = false
     @State private var showFailAlert = false
     @FocusState private var isFocused: Bool
     @State private var showEmptyState = false
     @State private var animateTip = false
+    
+    // Debounced loading to prevent excessive refreshes
+    @State private var loadTask: Task<Void, Never>?
+    
+    var displayText: String {
+        if isEditing {
+            return editingText
+        } else {
+            switch card.loadingState {
+            case .loading:
+                return "Loading…"
+            case .idle, .loaded, .error:
+                return card.currentText
+            }
+        }
+    }
     
     var body: some View {
         GeometryReader { geo in
@@ -30,71 +45,55 @@ struct CardView: View {
                     .frame(width: geo.size.width,
                            height: geo.safeAreaInsets.top + 44)
                     .ignoresSafeArea(edges: .top)
-                TextEditor(text: $text)
+                
+                TextEditor(text: isEditing ? $editingText : .constant(displayText))
                     .font(Font.body)
                     .frame(alignment: .topLeading)
                     .padding()
                     .focused($isFocused)
+                    .disabled(!isEditing)
                     .scrollDisabled(!isFocused)
-                    .onChange(of: isFocused) { _ in
-                        if locked {
-                            isFocused = false
-                        }
-                        if !locked && isFocused {
-                            cancelText = text
-                            let impact = UIImpactFeedbackGenerator(style: .light)
-                            impact.impactOccurred()
-                            showEmptyState = false
-                        }
-                        if !isFocused && text == "" {
-                            showEmptyState = true
-                        }
+                    .onChange(of: isFocused) { _, newValue in
+                        handleFocusChange(newValue)
                     }
-                    .onReceive(Just(text)) { _ in enforceLimit() }
-                    .gesture(DragGesture(minimumDistance: 44, coordinateSpace: .local).onEnded({ value in
-                        if value.translation.height < 0 {
-                            showMenu = true
+                    .onReceive(Just(editingText)) { _ in
+                        if isEditing { enforceLimit() }
+                    }
+                    .gesture(DragGesture(minimumDistance: 44, coordinateSpace: .local)
+                        .onEnded { value in
+                            if value.translation.height < 0 {
+                                showMenu = true
+                            }
                         }
-                    }))
+                    )
                     .toolbar {
                         ToolbarItem(placement: .keyboard) {
                             Button("Cancel") {
-                                text = cancelText
-                                isFocused = false
+                                cancelEditing()
                             }
                             .foregroundColor(Color(UIColor.link))
                         }
                         ToolbarItem(placement: .keyboard) {
                             Button("Save") {
-                                savedText = text
-                                Task {
-                                    do {
-                                        try await setText(card.saveRemote(savedText))
-                                    } catch {
-                                        saveFailure()
-                                    }
-                                }
-                                locked = true
-                                text = "Saving…"
-                                isFocused = false
+                                saveText()
                             }
                             .foregroundColor(Color(UIColor.link))
                         }
                     }
                     .sheet(isPresented: $showMenu) {
-                        SwipeMenu(shareText: text)
+                        SwipeMenu(shareText: card.currentText)
                     }
                     .alert("Error", isPresented: $showFailAlert, actions: {
                         Button("Cancel", role: .cancel) {
-                            text = cancelText
+                            cancelEditing()
                         }
                         Button("Try Again") {
-                            text = savedText
-                            isFocused = true
+                            saveText()
                         }
                     }, message: {
                         Text("There was a problem saving to the cloud.")
                     })
+                
                 Image("SwipeUp")
                     .resizable()
                     .frame(width: 48.0, height: 48.0)
@@ -103,71 +102,124 @@ struct CardView: View {
                     .opacity(showEmptyState ? 1 : 0)
                     .offset(y: animateTip ? -80 : 0)
                     .onTapGesture {
-                        if #available(iOS 17.0, *) {
-                            withAnimation(.easeInOut(duration: 0.5)) { animateTip = true } completion: { withAnimation { animateTip = false }
-                            }
-                        }
+                        animateSwipeUpTip()
                     }
             }
         }
-        .onAppear() { loadText() }
-        .onChange(of: scenePhase) { newValue in
-            switch newValue {
-            case .active:
-                performActionIfNeeded()
-                card.refreshCalled = true
-            default:
-                break
-            }
+        .task { // Initial load when view appears
+            await loadTextIfOld()
         }
-        .onChange(of: card.refreshCalled) { newValue in
-            if newValue { refreshText() }
+        .onChange(of: scenePhase) { _, newPhase in
+            handleScenePhaseChange(newPhase)
+        }
+        .onChange(of: card.currentText) { _, _ in
+            updateEmptyState()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .refreshRequested)) { _ in
+            Task {
+                await card.refresh()
+            }
         }
     }
     
-    func loadText() {
-        if isFocused { return }
+    // MARK: - Private Methods
+    
+    private func loadTextIfOld() async {
+        if Date().timeIntervalSince(card.lastRefreshTime) > 30 { // 5 minutes
+            await card.refresh()
+        }
+        updateEmptyState()
+    }
+    
+    private func handleFocusChange(_ focused: Bool) {
+        if focused && !isEditing {
+            startEditing()
+        } else if !focused && isEditing {
+            // User tapped away without saving - this is just canceling
+            cancelEditing()
+        }
+    }
+    
+    private func startEditing() {
+        isEditing = true
+        editingText = card.currentText
+        isFocused = true
+        showEmptyState = false
+        
+        let impact = UIImpactFeedbackGenerator(style: .light)
+        impact.impactOccurred()
+    }
+    
+    private func cancelEditing() {
+        isEditing = false
+        editingText = ""
+        isFocused = false
+        updateEmptyState()
+    }
+    
+    private func saveText() {
+        guard isEditing else { return }
+        guard networkMonitor.isConnected else { return }
+        
+        let textToSave = editingText
+        isEditing = false
+        isFocused = false
+        
         Task {
-            var loadedText: String
             do {
-                loadedText = try await card.loadRemote()
+                try await card.save(textToSave)
+                updateEmptyState()
             } catch {
-                loadedText = card.loadLocal()
+                // Re-enter editing mode with the text they were trying to save
+                isEditing = true
+                editingText = textToSave
+                showFailAlert = true
             }
-            setText(loadedText)
         }
     }
     
-    func refreshText() {
-        if isFocused { return }
-        card.refreshCalled = false
-        locked = true
-        text = "Loading…"
-        loadText()
+    private func updateEmptyState() {
+        showEmptyState = !isEditing && card.currentText.isEmpty
     }
     
-    func setText(_ returnText: String) {
-        locked = false
-        text = returnText
-        if returnText == "" { showEmptyState = true }
-        else { showEmptyState = false }
-    }
-    
-    func saveFailure() {
-        locked = false
-        showFailAlert = true
-    }
-    
-    func enforceLimit() {
+    private func enforceLimit() {
         let charLimit = 1034
-        if isFocused && text.count > charLimit {
-            Task { @MainActor in
-                text = String(text.prefix(charLimit))
+        if editingText.count > charLimit {
+            editingText = String(editingText.prefix(charLimit))
+        }
+    }
+    
+    private func handleScenePhaseChange(_ newPhase: ScenePhase) {
+        switch newPhase {
+        case .active:
+            performActionIfCalled()
+            // Debounced refresh when coming back to foreground
+            loadTask?.cancel()
+            loadTask = Task {
+                try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
+                if !Task.isCancelled {
+                    await loadTextIfOld()
+                }
+            }
+        case .background:
+            // Cancel any pending loads when going to background
+            loadTask?.cancel()
+        default:
+            break
+        }
+    }
+    
+    private func animateSwipeUpTip() {
+        withAnimation(.easeInOut(duration: 0.5)) {
+            animateTip = true
+        } completion: {
+            withAnimation {
+                animateTip = false
             }
         }
     }
     
-    func performActionIfNeeded() {
+    private func performActionIfCalled() {
         guard let action = actionService.action else { return }
         
         switch action {
@@ -183,6 +235,11 @@ struct CardView: View {
         
         actionService.action = nil
     }
+}
+
+// MARK: - Notification Extensions
+extension Notification.Name {
+    static let refreshRequested = Notification.Name("refreshRequested")
 }
 
 struct CardView_Previews: PreviewProvider {

--- a/Pastecard/CardView.swift
+++ b/Pastecard/CardView.swift
@@ -7,6 +7,7 @@
 
 import Combine
 import SwiftUI
+import PastecardCore
 
 struct CardView: View {
     @EnvironmentObject var card: Pastecard

--- a/Pastecard/NetworkMonitor.swift
+++ b/Pastecard/NetworkMonitor.swift
@@ -1,0 +1,28 @@
+//
+//  NetworkMonitor.swift
+//  Pastecard
+//
+//  Created by Brian Sutorius on 7/1/25.
+//
+
+import Network
+import SwiftUI
+
+class NetworkMonitor: ObservableObject {
+    @Published var isConnected = false
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "NetworkMonitor")
+    
+    init() {
+        monitor.pathUpdateHandler = { path in
+            DispatchQueue.main.async {
+                self.isConnected = path.status == .satisfied
+            }
+        }
+        monitor.start(queue: queue)
+    }
+    
+    deinit {
+        monitor.cancel()
+    }
+}

--- a/Pastecard/Pastecard.swift
+++ b/Pastecard/Pastecard.swift
@@ -13,6 +13,7 @@ import PastecardCore
     @Published var uid = ""
     @Published var currentText = ""
     @Published var loadingState: LoadingState = .idle
+    @Published var lastRefreshed = Date.distantPast
     
     private let core = PastecardCore.shared
     private let defaults = UserDefaults(suiteName: "group.net.pastecard")!

--- a/Pastecard/Pastecard.swift
+++ b/Pastecard/Pastecard.swift
@@ -73,7 +73,7 @@ import PastecardCore
             loadingState = .loaded
         } catch {
             loadingState = .error(error)
-            throw error
+            throw NetworkError.saveError
         }
     }
     

--- a/Pastecard/Pastecard.swift
+++ b/Pastecard/Pastecard.swift
@@ -6,23 +6,7 @@
 //
 
 import WidgetKit
-
-enum NetworkError: Error {
-    case timeout
-    case loadError
-    case saveError
-    case signInError
-    case deleteAcctError
-    case appendError
-}
-
-enum LoadingState {
-    case idle
-    case loading
-    case saving
-    case loaded
-    case error(Error)
-}
+import PastecardCore
 
 @MainActor class Pastecard: ObservableObject {
     @Published var isSignedIn: Bool
@@ -31,16 +15,14 @@ enum LoadingState {
     @Published var loadingState: LoadingState = .idle
     @Published var lastRefreshTime = Date()
     
-    let defaults = UserDefaults(suiteName: "group.net.pastecard")!
-    let session = URLSession(configuration: .ephemeral)
+    private let core = PastecardCore.shared
+    private let defaults = UserDefaults(suiteName: "group.net.pastecard")!
     
     init() {
-        if let savedUser = defaults.string(forKey: "ID") {
-            self.isSignedIn = true
+        self.isSignedIn = core.isSignedIn
+        if let savedUser = core.currentUser {
             self.uid = savedUser
-            self.currentText = loadLocal()
-        } else {
-            self.isSignedIn = false
+            self.currentText = core.loadLocal()
         }
     }
     
@@ -71,55 +53,15 @@ enum LoadingState {
         
         loadingState = .loading
         do {
-            let text = try await loadRemote()
+            let text = try await core.loadRemote()
             currentText = text
             loadingState = .loaded
             lastRefreshTime = Date()
         } catch {
-            currentText = loadLocal()
+            currentText = core.loadLocal()
             loadingState = .error(error)
             throw NetworkError.loadError
         }
-    }
-    
-    func deleteAcct() async throws {
-        let url = URL(string: "https://pastecard.net/api/ios-deleteacct.php?user=" + (self.uid.addingPercentEncoding(withAllowedCharacters: .urlUserAllowed))!)
-        let (data, response) = try await session.data(from: url!)
-        guard (response as? HTTPURLResponse)?.statusCode == 200 else {
-            throw NetworkError.deleteAcctError
-        }
-        let responseString = String(decoding: data, as: UTF8.self)
-        if responseString == "success" {
-            self.signOut()
-        } else {
-            throw NetworkError.deleteAcctError
-        }
-    }
-    
-    private func loadLocal() -> String {
-        var returnText = ""
-        if let localText = defaults.string(forKey: "text") {
-            if !localText.isEmpty {
-                returnText = localText
-            }
-        }
-        return returnText
-    }
-
-    private func loadRemote() async throws -> String {
-        var returnText = ""
-        let randomInt = String(Int.random(in: 1...1000))
-        let url = URL(string: "https://pastecard.net/api/db/" + self.uid + ".txt?" + randomInt)!
-        
-        let (data, response) = try await session.data(from: url)
-        let remoteText = String(decoding: data, as: UTF8.self)
-        guard (response as? HTTPURLResponse)?.statusCode == 200 else {
-            throw NetworkError.loadError
-        }
-        
-        if !remoteText.isEmpty { returnText = remoteText }
-        self.saveLocal(returnText)
-        return returnText
     }
     
     func save(_ text: String) async throws {
@@ -127,7 +69,7 @@ enum LoadingState {
         
         loadingState = .saving
         do {
-            let savedText = try await saveRemote(text)
+            let savedText = try await core.saveRemote(text)
             currentText = savedText
             loadingState = .loaded
         } catch {
@@ -136,27 +78,8 @@ enum LoadingState {
         }
     }
     
-    private func saveLocal(_ text: String) {
-        defaults.set(text, forKey: "text")
-        WidgetCenter.shared.reloadTimelines(ofKind: "PCWidget")
-    }
-    
-    private func saveRemote(_ text: String) async throws -> String {
-        let sendText = text.addingPercentEncoding(withAllowedCharacters: .alphanumerics)!
-        let postData = ("user=" + self.uid + "&text=" + sendText)
-        let url = URL(string: "https://pastecard.net/api/ios-write.php")!
-        
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.httpBody = postData.data(using: String.Encoding.utf8)
-        request.timeoutInterval = 5.0
-        let (data, response) = try await session.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-            throw NetworkError.saveError
-        }
-        
-        let returnText = String(decoding: data, as: UTF8.self).removingPercentEncoding
-        self.saveLocal(returnText!)
-        return returnText!
+    func delete() async throws {
+        try await core.deleteAccount()
+        self.signOut()
     }
 }

--- a/Pastecard/Pastecard.swift
+++ b/Pastecard/Pastecard.swift
@@ -13,7 +13,6 @@ import PastecardCore
     @Published var uid = ""
     @Published var currentText = ""
     @Published var loadingState: LoadingState = .idle
-    @Published var lastRefreshTime = Date()
     
     private let core = PastecardCore.shared
     private let defaults = UserDefaults(suiteName: "group.net.pastecard")!
@@ -56,7 +55,6 @@ import PastecardCore
             let text = try await core.loadRemote()
             currentText = text
             loadingState = .loaded
-            lastRefreshTime = Date()
         } catch {
             currentText = core.loadLocal()
             loadingState = .error(error)

--- a/Pastecard/Shortcuts.swift
+++ b/Pastecard/Shortcuts.swift
@@ -13,11 +13,15 @@ struct PastecardShortcuts: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {
         AppShortcut(
             intent: GetText(),
-            phrases: ["What's on my \(.applicationName)", "Read me my \(.applicationName)"]
+            phrases: ["What's on my \(.applicationName)", "Read me my \(.applicationName)"],
+            shortTitle: "Get Text",
+            systemImageName: "inset.filled.topthird.square"
         )
         AppShortcut(
             intent: AppendText(),
-            phrases: ["Add something to my \(.applicationName)"]
+            phrases: ["Add something to my \(.applicationName)"],
+            shortTitle: "Add Text",
+            systemImageName: "plus.square"
         )
     }
 }

--- a/Pastecard/SignInView.swift
+++ b/Pastecard/SignInView.swift
@@ -134,9 +134,9 @@ struct SignInView: View {
         idFocus = false
         
         let nameCheck = userId.lowercased().trimmingCharacters(in: .whitespaces)
-        let url = URL(string: "https://pastecard.net/api/ios-signin.php?user=" + (nameCheck.addingPercentEncoding(withAllowedCharacters: .urlUserAllowed))!)!
+        let url = URL(string: "https://pastecard.net/api/ios-signin.php?user=" + (nameCheck.addingPercentEncoding(withAllowedCharacters: .urlUserAllowed))!)
         
-        var request = URLRequest(url: url)
+        var request = URLRequest(url: url!)
         request.timeoutInterval = 10.0
         
         let (data, response) = try await URLSession.shared.data(for: request)
@@ -153,7 +153,7 @@ struct SignInView: View {
                 }
             }
         } else {
-            errorMessage = "Sorry, the computer can't find that ID."
+            errorMessage = "Sorry, the computer can’t find that ID."
         }
     }
     

--- a/Pastecard/SignInView.swift
+++ b/Pastecard/SignInView.swift
@@ -134,9 +134,12 @@ struct SignInView: View {
         idFocus = false
         
         let nameCheck = userId.lowercased().trimmingCharacters(in: .whitespaces)
-        let url = URL(string: "https://pastecard.net/api/ios-signin.php?user=" + (nameCheck.addingPercentEncoding(withAllowedCharacters: .urlUserAllowed))!)
+        let url = URL(string: "https://pastecard.net/api/ios-signin.php?user=" + (nameCheck.addingPercentEncoding(withAllowedCharacters: .urlUserAllowed))!)!
         
-        let (data, response) = try await URLSession.shared.data(from: url!)
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10.0
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
         guard (response as? HTTPURLResponse)?.statusCode == 200 else {
             throw NetworkError.signInError
         }
@@ -150,7 +153,7 @@ struct SignInView: View {
                 }
             }
         } else {
-            errorMessage = "Sorry, the computer can’t find that ID."
+            errorMessage = "Sorry, the computer can't find that ID."
         }
     }
     

--- a/Pastecard/SignInView.swift
+++ b/Pastecard/SignInView.swift
@@ -148,7 +148,13 @@ struct SignInView: View {
         }
         let responseString = String(data: data, encoding: .utf8)
         if responseString == "success" {
-            Task { await card.signIn(nameCheck) }
+            Task {
+                do {
+                    try await card.signIn(nameCheck)
+                } catch {
+                    throw NetworkError.signInError
+                }
+            }
         } else {
             errorMessage = "Sorry, the computer can’t find that ID."
         }

--- a/Pastecard/SignInView.swift
+++ b/Pastecard/SignInView.swift
@@ -7,6 +7,7 @@
 
 import Combine
 import SwiftUI
+import PastecardCore
 
 struct SignInView: View {
     @EnvironmentObject var card: Pastecard
@@ -24,16 +25,9 @@ struct SignInView: View {
         GeometryReader { geo in
             List {
                 HStack(alignment: .center) {
-                    if #available(iOS 17.0, *) {
-                        Text("Pastecard")
-                            .font(Font.largeTitle.weight(.bold))
-                            .frame(maxWidth: .infinity)
-                    } else {
-                        Text("Pastecard")
-                            .font(Font.largeTitle.weight(.bold))
-                            .frame(maxWidth: .infinity)
-                            .padding(.top, geo.safeAreaInsets.top + 44)
-                    }
+                    Text("Pastecard")
+                    .font(Font.largeTitle.weight(.bold))
+                    .frame(maxWidth: .infinity)
                 }
                 .listRowBackground(Color.primary.opacity(0))
                 .onTapGesture {

--- a/Pastecard/SignInView.swift
+++ b/Pastecard/SignInView.swift
@@ -58,12 +58,12 @@ struct SignInView: View {
                                     }
                                 }
                             }
-                            .onChange(of: userId) { _ in
+                            .onChange(of: userId) { _, newValue in
                                 if userId == "" {
                                     errorMessage = ""
                                 }
                             }
-                            .onChange(of: idFocus) { _ in
+                            .onChange(of: idFocus) { _, newValue in
                                 if idFocus { impact.impactOccurred() }
                             }
                         Spacer()
@@ -118,10 +118,10 @@ struct SignInView: View {
                     .padding(.top, -geo.safeAreaInsets.top)
             }
         }
-        .onChange(of: scenePhase) { newValue in
+        .onChange(of: scenePhase) { _, newValue in
             switch newValue {
             case .active:
-                performActionIfNeeded()
+                performActionIfCalled()
             default:
                 break
             }
@@ -154,7 +154,7 @@ struct SignInView: View {
         }
     }
     
-    func performActionIfNeeded() {
+    func performActionIfCalled() {
         guard let action = actionService.action else { return }
         
         switch action {

--- a/Pastecard/SignUpSheet.swift
+++ b/Pastecard/SignUpSheet.swift
@@ -67,7 +67,7 @@ struct SignUpSheet: View {
             let (data, _) = try await URLSession.shared.data(from: url)
             let responseString = String(data: data, encoding: .utf8)
             if responseString == "success" {
-                await card.signIn(name)
+                try await card.signIn(name)
             } else if responseString == "taken" {
                 errorMessage = "Sorry, that ID is not available."
             } else {

--- a/Pastecard/SignUpSheet.swift
+++ b/Pastecard/SignUpSheet.swift
@@ -61,9 +61,9 @@ struct SignUpSheet: View {
         if invalidID { return }
         
         let name = newUser.lowercased().trimmingCharacters(in: .whitespaces)
-        let url = URL(string: "https://pastecard.net/api/ios-signup.php?user=" + (name.addingPercentEncoding(withAllowedCharacters: .urlUserAllowed))!)!
+        let url = URL(string: "https://pastecard.net/api/ios-signup.php?user=" + (name.addingPercentEncoding(withAllowedCharacters: .urlUserAllowed))!)
         
-        var request = URLRequest(url: url)
+        var request = URLRequest(url: url!)
         request.timeoutInterval = 10.0
         
         do {
@@ -74,10 +74,10 @@ struct SignUpSheet: View {
             } else if responseString == "taken" {
                 errorMessage = "Sorry, that ID is not available."
             } else {
-                errorMessage = "Oops, something didn't work. Please try again."
+                errorMessage = "Oops, something didn’t work. Please try again."
             }
         } catch {
-            errorMessage = "Oops, something didn't work. Please try again."
+            errorMessage = "Oops, something didn’t work. Please try again."
         }
     }
     

--- a/Pastecard/SignUpSheet.swift
+++ b/Pastecard/SignUpSheet.swift
@@ -63,18 +63,21 @@ struct SignUpSheet: View {
         let name = newUser.lowercased().trimmingCharacters(in: .whitespaces)
         let url = URL(string: "https://pastecard.net/api/ios-signup.php?user=" + (name.addingPercentEncoding(withAllowedCharacters: .urlUserAllowed))!)!
         
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10.0
+        
         do {
-            let (data, _) = try await URLSession.shared.data(from: url)
+            let (data, _) = try await URLSession.shared.data(for: request)
             let responseString = String(data: data, encoding: .utf8)
             if responseString == "success" {
                 try await card.signIn(name)
             } else if responseString == "taken" {
                 errorMessage = "Sorry, that ID is not available."
             } else {
-                errorMessage = "Oops, something didn’t work. Please try again."
+                errorMessage = "Oops, something didn't work. Please try again."
             }
         } catch {
-            errorMessage = "Oops, something didn’t work. Please try again."
+            errorMessage = "Oops, something didn't work. Please try again."
         }
     }
     

--- a/Pastecard/SignUpSheet.swift
+++ b/Pastecard/SignUpSheet.swift
@@ -25,7 +25,7 @@ struct SignUpSheet: View {
                     .background(Color(UIColor.systemBackground))
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled(true)
-                    .onChange(of: newUser) { newValue in
+                    .onChange(of: newUser) { _, newValue in
                         validate()
                     }
                     .onSubmit { Task { await signUp() } }

--- a/Pastecard/SwipeMenu.swift
+++ b/Pastecard/SwipeMenu.swift
@@ -107,7 +107,11 @@ struct SwipeMenu: View {
         isRefreshing = true
         
         Task {
-            await card.refresh()
+            do {
+                try await card.refresh()
+            } catch {
+                throw NetworkError.signInError
+            }
             await MainActor.run {
                 isRefreshing = false
                 dismiss()

--- a/Pastecard/SwipeMenu.swift
+++ b/Pastecard/SwipeMenu.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import PastecardCore
 
 struct menuCell: View {
     let symbol: String
@@ -92,7 +93,7 @@ struct SwipeMenu: View {
             Button("Delete", role: .destructive) {
                 self.dismiss()
                 Task {
-                    do { try await card.deleteAcct() }
+                    do { try await card.delete() }
                     catch { }
                 }
             }

--- a/Pastecard/SwipeMenu.swift
+++ b/Pastecard/SwipeMenu.swift
@@ -29,7 +29,6 @@ struct SwipeMenu: View {
     
     @State private var showSVC = false
     @State private var showDeleteAlert = false
-    @State private var isRefreshing = false
     var shareText: String
     
     var body: some View {
@@ -39,21 +38,14 @@ struct SwipeMenu: View {
                     refreshCard()
                 } label: {
                     HStack {
-                        if isRefreshing {
-                            ProgressView()
-                                .scaleEffect(0.8)
-                                .frame(width: 20)
-                        } else {
-                            Image(systemName: "arrow.clockwise")
-                                .font(Font.body.weight(.semibold))
-                                .frame(width: 20)
-                        }
+                        Image(systemName: "arrow.clockwise")
+                            .font(Font.body.weight(.semibold))
+                            .frame(width: 20)
                         Text("Refresh")
                     }
-                    .foregroundColor(isRefreshing ? .secondary : .primary)
+                    .foregroundColor(.primary)
                 }
-                .disabled(isRefreshing)
-
+                
                 ShareLink (
                     item: shareText
                 ) {
@@ -73,7 +65,7 @@ struct SwipeMenu: View {
                     card.signOut()
                 } label: {
                     menuCell(symbol: "rectangle.portrait.and.arrow.forward", label: "Sign Out")
-
+                    
                 }
                 Button {
                     showDeleteAlert = true
@@ -105,8 +97,6 @@ struct SwipeMenu: View {
     private func refreshCard() {
         guard networkMonitor.isConnected else { return }
         
-        isRefreshing = true
-        
         Task {
             do {
                 try await card.refresh()
@@ -114,7 +104,6 @@ struct SwipeMenu: View {
                 throw NetworkError.signInError
             }
             await MainActor.run {
-                isRefreshing = false
                 dismiss()
             }
         }

--- a/PastecardCore/.gitignore
+++ b/PastecardCore/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/PastecardCore/Package.swift
+++ b/PastecardCore/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "PastecardCore",
+    platforms: [.iOS(.v17)],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "PastecardCore",
+            targets: ["PastecardCore"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "PastecardCore"),
+
+    ]
+)

--- a/PastecardCore/Sources/PastecardCore/PastecardCore.swift
+++ b/PastecardCore/Sources/PastecardCore/PastecardCore.swift
@@ -36,9 +36,10 @@ public enum LoadingState: Equatable {
     }
 }
 
+@MainActor
 @available(iOS 17.0, *)
 public class PastecardCore {
-    @MainActor public static let shared = PastecardCore()
+    public static let shared = PastecardCore()
     
     private let defaults = UserDefaults(suiteName: "group.net.pastecard")!
     private let session = URLSession(configuration: .ephemeral)

--- a/PastecardCore/Sources/PastecardCore/PastecardCore.swift
+++ b/PastecardCore/Sources/PastecardCore/PastecardCore.swift
@@ -1,0 +1,151 @@
+//
+//  PastecardCore.swift
+//  Pastecard
+//
+//  Created by Brian Sutorius on 7/2/25.
+//
+
+import Foundation
+import WidgetKit
+
+public enum NetworkError: Error {
+    case timeout
+    case loadError
+    case saveError
+    case signInError
+    case deleteAcctError
+    case appendError
+}
+
+public enum LoadingState: Equatable {
+    case idle
+    case loading
+    case saving
+    case loaded
+    case error(Error)
+    
+    public static func == (lhs: LoadingState, rhs: LoadingState) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle), (.loading, .loading), (.saving, .saving), (.loaded, .loaded):
+            return true
+        case (.error, .error):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+public class PastecardCore {
+    @MainActor public static let shared = PastecardCore()
+    
+    private let defaults = UserDefaults(suiteName: "group.net.pastecard")!
+    private let session = URLSession(configuration: .ephemeral)
+    
+    private init() {}
+    
+    public var currentUser: String? {
+        return defaults.string(forKey: "ID")
+    }
+    
+    public var isSignedIn: Bool {
+        return currentUser != nil
+    }
+    
+    public func loadLocal() -> String {
+        var returnText = ""
+        if let localText = defaults.string(forKey: "text") {
+            if !localText.isEmpty {
+                returnText = localText
+            }
+        }
+        return returnText
+    }
+    
+    public func loadRemote() async throws -> String {
+        guard let uid = currentUser else {
+            throw NetworkError.signInError
+        }
+        
+        var returnText = ""
+        let randomInt = String(Int.random(in: 1...1000))
+        let url = URL(string: "https://pastecard.net/api/db/" + uid + ".txt?" + randomInt)!
+        
+        let (data, response) = try await session.data(from: url)
+        let remoteText = String(decoding: data, as: UTF8.self)
+        guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+            throw NetworkError.loadError
+        }
+        
+        if !remoteText.isEmpty { returnText = remoteText }
+        saveLocal(returnText)
+        return returnText
+    }
+    
+    public func saveLocal(_ text: String) {
+        defaults.set(text, forKey: "text")
+        WidgetCenter.shared.reloadTimelines(ofKind: "PCWidget")
+    }
+    
+    public func saveRemote(_ text: String) async throws -> String {
+        guard let uid = currentUser else {
+            throw NetworkError.signInError
+        }
+        
+        let sendText = text.addingPercentEncoding(withAllowedCharacters: .alphanumerics)!
+        let postData = ("user=" + uid + "&text=" + sendText)
+        let url = URL(string: "https://pastecard.net/api/ios-write.php")!
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = postData.data(using: String.Encoding.utf8)
+        request.timeoutInterval = 5.0
+        
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw NetworkError.saveError
+        }
+        
+        let returnText = String(decoding: data, as: UTF8.self).removingPercentEncoding
+        saveLocal(returnText!)
+        return returnText!
+    }
+    
+    public func append(_ text: String) async throws {
+        guard let uid = currentUser else {
+            throw NetworkError.signInError
+        }
+        
+        let sendText = text.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? ""
+        let postData = ("user=" + uid + "&text=" + sendText)
+        let url = URL(string: "https://pastecard.net/api/ios-append.php")!
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = postData.data(using: String.Encoding.utf8)
+        request.timeoutInterval = 5.0
+        
+        let (_, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw NetworkError.appendError
+        }
+    }
+    
+    public func deleteAccount() async throws {
+        guard let uid = currentUser else {
+            throw NetworkError.signInError
+        }
+        
+        let url = URL(string: "https://pastecard.net/api/ios-deleteacct.php?user=" + (uid.addingPercentEncoding(withAllowedCharacters: .urlUserAllowed))!)
+        let (data, response) = try await session.data(from: url!)
+        guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+            throw NetworkError.deleteAcctError
+        }
+        
+        let responseString = String(decoding: data, as: UTF8.self)
+        if responseString != "success" {
+            throw NetworkError.deleteAcctError
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 * All the warm feelings of a native SwiftUI app
 
 ## A few notes
-* iOS 16 or later required
+* iOS 17 or later required
 * __Swipe up__ on the card to force a refresh, share the card text to another app, or sign out
 * See [Pastecard Help](https://pastecard.net/help/) for more information
 * Refer to [this walkthrough](https://osxdaily.com/2016/01/12/howto-sideload-apps-iphone-ipad-xcode/) for help sideloading apps via Xcode


### PR DESCRIPTION
With assistance from Claude:
- abstract all card functions to a new PastecardCore package
  - the iOS app, widget, and share extension use equally
  - this will make it easier to add new clients like Mac or watch in the future
- make the network functions more modern and robust
  - implement timeouts on major network functions
  - make card refresh when launching or returning to the app more reliable
  - this will make it easier to migrate to a new infrastructure in the future
- set minimum iOS version to 17
  - avoid differences in widget rendering
  - assume can animate SF Symbol on empty card